### PR TITLE
chore(docs): fixes incorrect example of HOTP

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,28 +61,29 @@ ExOtp.valid_totp?(totp, otp, DateTime.utc_now())
 - Create a HOTP object using either a random secret or  a user-provided secret as follows:
 ```elixir
 secret = ExOtp.random_secret()
+counter = 30
 #=> "uapgaiacdaptafbu"
-totp = ExOtp.create_hotp(secret, 30) # Specify initial count 
+hotp = ExOtp.create_hotp(secret, counter) # Specify initial count 
 #=> %ExOtp.Hotp{
 #  base: %ExOtp.Base{
 #    digest: :sha,
 #    digits: 6,
 #    secret: "OVQXAZ3BNFQWGZDBOB2GCZTCOU======"
 #  },
-#  initial_count: 0
+#  initial_count: 30
 #}
 ```
 
 - Generate an otp using the `hotp` object, for a given datetime value:
 ```elixir
-otp = ExOtp.generate_hotp(hotp, DateTime.utc_now())
+otp = ExOtp.generate_hotp(hotp, counter)
 #=> "268374"
 ```
 
 - Finally, you can check if the otp is valid using the `otp` and `hotp` objects:
 
 ```elixir
-ExOtp.valid_hotp?(hotp, otp, 0) # Specify counter value
+ExOtp.valid_hotp?(hotp, otp, counter) # Specify counter value
 #=> true
 ```
 

--- a/lib/ex_otp/base.ex
+++ b/lib/ex_otp/base.ex
@@ -6,7 +6,7 @@ defmodule ExOtp.Base do
   alias ExOtp.Errors
   alias Base, as: ElixirBase
 
-  use Bitwise
+  import Bitwise
 
   @keys [
     :secret,

--- a/lib/ex_otp/base.ex
+++ b/lib/ex_otp/base.ex
@@ -89,8 +89,8 @@ defmodule ExOtp.Base do
     |> bor((one &&& 0xFF) <<< 16)
     |> bor((two &&& 0xFF) <<< 8)
     |> bor(three &&& 0xFF)
-    # Round is required to convert float to integer
-    |> rem(:math.pow(10, digits) |> round())
+    # Floor is required to convert float to integer
+    |> rem(:math.pow(10, digits) |> floor())
   end
 
   # Private API

--- a/lib/ex_otp/totp.ex
+++ b/lib/ex_otp/totp.ex
@@ -42,7 +42,7 @@ defmodule ExOtp.Totp do
       for_time
       |> DateTime.to_unix()
       |> Kernel./(interval)
-      |> round()
+      |> floor()
       |> Kernel.+(counter)
     )
   end


### PR DESCRIPTION
I noticed that HOTP example is incorrect (using time instead of counter), so I changed that.